### PR TITLE
Upgrade to ppxlib.0.14.0

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -154,9 +154,7 @@ let capture_compiler_stuff ppf ~f =
 let apply_rewriters = function
   | Ptop_dir _ as x -> x
   | Ptop_def s ->
-    Ptop_def (Driver.map_structure s
-              |> Migrate_parsetree.Driver.migrate_some_structure
-                   (module Ppxlib_ast.Selected_ast))
+    Ptop_def (Driver.map_structure s)
 ;;
 
 let verbose = ref false

--- a/toplevel_expect_test.opam
+++ b/toplevel_expect_test.opam
@@ -23,7 +23,7 @@ depends: [
   "dune"                {>= "2.0.0"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ocamlfind"           {>= "1.7.2"}
-  "ppxlib"              {>= "0.11.0"}
+  "ppxlib"              {>= "0.14.0"}
 ]
 synopsis: "Expectation tests for the OCaml toplevel"
 description: "


### PR DESCRIPTION
The next release of ppxlib will remove some reference to OMP's API since those will be removed when omp.2.0.0 is released. This PR makes toplevel_expect_test compatible with the new API. Might be worth waiting for the new ppxlib release before merging it.